### PR TITLE
docs(typedoc-gen): change mode to file

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,5 @@
 {
     "inputFiles": ["./src"],
-    "mode": "modules",
+    "mode": "file",
     "json": "./docs.json"
 }


### PR DESCRIPTION
### Description of the PR

Setting the mode to "file" creates a much more readable HTML layout for Typedoc, for an example see https://skyra-project.github.io/skyra-decorators/, comparing it to for example https://dirigeants.github.io/klasa/. The difference being of course that with "modules" you get an extremely long list of files, most of which only have 1 or 2 exports. Furthermore the layout of "files" is much more in line with the layout of a page such as the "Classes" tab on https://klasa.js.org/#/docs/klasa/settings/Getting%20Started/GettingStarted.

Kyra told me to PR this change: ![](https://favna.s-ul.eu/Lv9MNbgz.png)

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Change of how typedoc outputs files so the HTML rendered page looks much better

### Semver Classification

- [x] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
